### PR TITLE
Add sampling arguments

### DIFF
--- a/easynmt/models/OpusMT.py
+++ b/easynmt/models/OpusMT.py
@@ -41,7 +41,7 @@ class OpusMT:
             self.models[model_name] = {'tokenizer': tokenizer, 'model': model, 'last_loaded': time.time()}
             return tokenizer, model
 
-    def translate_sentences(self, sentences: List[str], source_lang: str, target_lang: str, device: str, beam_size: int = 5, max_length: int = None):
+    def translate_sentences(self, sentences: List[str], source_lang: str, target_lang: str, device: str, beam_size: int = 5, max_length: int = None, do_sample=False, top_k=50, top_p=1.0):
         model_name = 'Helsinki-NLP/opus-mt-{}-{}'.format(source_lang, target_lang)
         tokenizer, model = self.load_model(model_name)
         model.to(device)
@@ -52,7 +52,7 @@ class OpusMT:
             inputs[key] = inputs[key].to(device)
 
         with torch.no_grad():
-            translated = model.generate(**inputs, num_beams=beam_size)
+            translated = model.generate(**inputs, num_beams=beam_size, do_sample=do_sample, top_k=top_k, top_p=top_p)
             output = [tokenizer.decode(t, skip_special_tokens=True) for t in translated]
 
         return output


### PR DESCRIPTION
This PR adds sampling options to generation, which is useful for [augmentation through back-translation](https://arxiv.org/abs/1808.09381).

I set the default values as the same from [HF Transformers](https://huggingface.co/transformers/main_classes/model.html?highlight=generate#transformers.generation_utils.GenerationMixin.generate), let me know if you have any suggestion.

Thanks for the awesome package btw!

Example of usage:

```python
model.translate(sentences, target_lang='de', beam_size=1, do_sample=True, top_k=10)
```