### PR TITLE
Update to enable max_length parameter for AutoModels/M2M-100

### DIFF
--- a/easynmt/models/AutoModel.py
+++ b/easynmt/models/AutoModel.py
@@ -42,7 +42,7 @@ class AutoModel:
             target_lang = self.lang_map[target_lang]
 
         self.tokenizer.src_lang = source_lang
-        inputs = self.tokenizer(sentences, truncation=True, padding=True, return_tensors="pt")
+        inputs = self.tokenizer(sentences, truncation=True, padding=True, return_tensors="pt", max_length=self.max_length)
 
         for key in inputs:
             inputs[key] = inputs[key].to(device)


### PR DESCRIPTION
Bug fix - max_length parameter was not being propagated to AutoModel tokenizers. This was causing OOM for my system on large document inputs.