### PR TITLE
Fix exception that occurs when language not supported

### DIFF
--- a/easynmt/EasyNMT.py
+++ b/easynmt/EasyNMT.py
@@ -258,9 +258,12 @@ class EasyNMT:
                 logger.info("Translate sentences of language: {}".format(lng))
                 try:
                     grouped_sentences = [sentences[idx] for idx in ids]
-                    translated = self.translate_sentences(grouped_sentences, source_lang=lng, target_lang=target_lang, show_progress_bar=show_progress_bar, beam_size=beam_size, batch_size=batch_size, **kwargs)
-                    for idx, translated_sentences in zip(ids, translated):
-                        output[idx] = translated_sentences
+                    if lng + '-' + target_lang in self._lang_pairs:
+                        translated = self.translate_sentences(grouped_sentences, source_lang=lng, target_lang=target_lang, show_progress_bar=show_progress_bar, beam_size=beam_size, batch_size=batch_size, **kwargs)
+                        for idx, translated_sentences in zip(ids, translated):
+                            output[idx] = translated_sentences
+                    else:
+                        logger.info("Could not translate: {}".format(lng))
                 except Exception as e:
                     logger.warning("Exception: "+str(e))
                     raise e


### PR DESCRIPTION
Instead of generating an exception when a language is not supported, this will simply output a 'None' type for those translations, and the rest of the supported languages will still be translated.